### PR TITLE
Nprogress entire stylesheet

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,5 @@
 import 'normalize.css'
-import 'nprogress/nprogress.css'
+import '../styles/nprogress.scss'
 import '../styles/global.scss'
 import PropTypes from 'prop-types'
 import NProgress from 'nprogress'

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -64,17 +64,6 @@ button {
   }
 }
 
-#nprogress {
-  .bar {
-    background-color: v.$true-black;
-  }
-
-  .spinner-icon {
-    border-left-color: v.$true-black;
-    border-top-color: v.$true-black;
-  }
-}
-
 p {
   margin: 0;
 

--- a/styles/nprogress.scss
+++ b/styles/nprogress.scss
@@ -1,0 +1,69 @@
+@use 'variables' as v;
+
+$bar-color: v.$true-black;
+
+#nprogress {
+  pointer-events: none;
+
+  .bar {
+    background: $bar-color;
+    height: 2px;
+    left: 0;
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: 1031;
+  }
+
+  .peg {
+    box-shadow: 0 0 10px $bar-color, 0 0 5px $bar-color;
+    display: block;
+    height: 100%;
+    opacity: 1;
+    position: absolute;
+    right: 0;
+    transform: rotate(3deg) translate(0, -4px);
+    width: 100px;
+  }
+
+  .spinner {
+    display: block;
+    position: fixed;
+    right: 15px;
+    top: 15px;
+    z-index: 1031;
+  }
+
+  .spinner-icon {
+    animation: nprogress-spinner 400ms linear infinite;
+    border: solid 2px transparent;
+    border-left-color: $bar-color;
+    border-radius: 50%;
+    border-top-color: $bar-color;
+    box-sizing: border-box;
+    height: 18px;
+    width: 18px;
+  }
+}
+
+.nprogress-custom-parent {
+  overflow: hidden;
+  position: relative;
+
+  #nprogress {
+    .spinner,
+    .bar {
+      position: absolute;
+    }
+  }
+}
+
+@keyframes nprogress-spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
This PR converts the original `nprogress` stylesheet to scss without the need to import the dependecy stylesheet. I did this for more control over the bar and also sort of a reference guide to what is changeable inside the nprogress stylesheet.