### PR TITLE
add plugin for storybook preview router

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,6 @@
 // Styles that need to be globally accessible to components
+import { withNextRouter } from 'storybook-addon-next-router'
+import { addDecorator } from '@storybook/react'
 import 'normalize.css'
 import '../styles/global.scss'
 
@@ -66,3 +68,13 @@ Object.defineProperty(nextImage, 'default', {
     )
   },
 })
+
+// Mock router in order to work with next/link
+addDecorator(
+  withNextRouter({
+    path: '/', // defaults to `/`
+    asPath: '/', // defaults to `/`
+    query: {}, // defaults to `{}`
+    push() {}, // defaults to using addon actions integration, can override any method in the router
+  })
+)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-dom": "^17.0.1",
     "react-slick": "^0.27.14",
     "sass": "^1.32.5",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "storybook-addon-next-router": "^2.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11406,6 +11406,11 @@ store2@^2.7.1:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.12.0.tgz#e1f1b7e1a59b6083b2596a8d067f6ee88fd4d3cf"
   integrity sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==
 
+storybook-addon-next-router@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/storybook-addon-next-router/-/storybook-addon-next-router-2.0.3.tgz#24cb0233c03749a9b416f5b191bbcd17545a3d3b"
+  integrity sha512-1/q3ZYpN2Hae8ePL553J4rzVEh2rF+mVPvui2+Q7LEVvCTFgcB3Iow9xCA0P9nxNjg+oPs8Xkpb0ahXkwUAIcQ==
+
 stream-browserify@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"


### PR DESCRIPTION
@bretmorris Added this to NYHS and it fixes issue with storybook components using `next/link` (ie header with logo linked to homepage in the case of NYHS)