### PR TITLE
metadata lib with additional defaults logic

### DIFF
--- a/components/Carousel/index.js
+++ b/components/Carousel/index.js
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import Slider from 'react-slick'
 import PropTypes from 'prop-types'
-import prismicImageShare from 'shapes/prismic/image'
+import prismicImageShape from 'shapes/prismic/image'
 import 'slick-carousel/slick/slick.css'
 import 'slick-carousel/slick/slick-theme.css'
 
@@ -30,7 +30,7 @@ const Carousel = ({ items }) => {
 Carousel.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.shape({
-      image: prismicImageShare,
+      image: prismicImageShape,
     })
   ).isRequired,
 }

--- a/components/Layout/index.js
+++ b/components/Layout/index.js
@@ -10,7 +10,8 @@ import metaShape from 'components/Meta/shape'
 const Layout = ({ metadata, header, preview, children }) => {
   return (
     <>
-      <Meta metadata={metadata} />
+      {/* TODO create defaults in Prismic singleton */}
+      <Meta metadata={metadata} defaults={null} />
       {preview && <PreviewBar />}
       <Header header={header} />
       {/* TODO: customize your transition animation */}

--- a/components/Meta/index.js
+++ b/components/Meta/index.js
@@ -1,17 +1,21 @@
 import Head from 'next/head'
 import metaShape from './shape'
+import metaDefaults from 'constants/metadata'
 
-const Meta = ({ metadata }) => {
-  // TODO: update default metadata
-  const metaDefaults = {
-    TWITTER_HANDLE: '{@twitterHandle}',
-    TITLE: '{Default Title}',
-    DESCRIPTION: '{Default description}',
-    IMAGE: '{path_to_share_image.jpg}',
-  }
-  const title = metadata?.meta_title || metaDefaults.TITLE
-  const description = metadata?.meta_description || metaDefaults.DESCRIPTION
-  const image = metadata?.meta_image?.url || metaDefaults.IMAGE
+const Meta = ({ metadata, defaults }) => {
+  // Set metadata with page-specific settings, OR fallback to prismic defaults, OR finally fallback to defaults set in /constants/metadata file
+  const pageTitle = metadata?.meta_title || defaults?.title
+  const _title = pageTitle
+    ? pageTitle + ' ' + metaDefaults.DIVIDER + ' ' + metaDefaults.TITLE
+    : null
+  const title = _title || metaDefaults.TITLE
+  const description =
+    metadata?.meta_description ||
+    defaults?.description ||
+    metaDefaults.DESCRIPTION
+  const image =
+    metadata?.meta_image?.url || defaults?.image?.url || metaDefaults.IMAGE
+
   return (
     <Head>
       <link
@@ -56,6 +60,7 @@ const Meta = ({ metadata }) => {
 
 Meta.propTypes = {
   metadata: metaShape,
+  defaults: metaShape,
 }
 
 export default Meta

--- a/components/Meta/lib.js
+++ b/components/Meta/lib.js
@@ -1,0 +1,33 @@
+export function getMetaData(doc) {
+  // Determine template overrides
+  const metadata = {
+    meta_title: null,
+    meta_divider: null,
+    meta_description: null,
+    meta_image: null,
+  }
+
+  if (!doc || !doc.data) return metadata
+
+  // Every template in Prismic should have these override options (TODO ensure exact naming in your project)
+  // And then each template may have specifics for determining default metadata fields if these overrides are left blank
+  const { meta_title, meta_description, meta_image } = doc.data
+
+  switch (doc.type) {
+    case 'blog_post':
+      // TODO remove this and add in your own template override options
+      metadata.meta_title = meta_title || doc.data.post_title
+      metadata.meta_description = meta_description || doc.data.post_description
+      metadata.meta_image = meta_image?.url || doc.data.post_image
+
+      break
+    default:
+      metadata.meta_title = meta_title
+      metadata.meta_description = meta_description
+      metadata.meta_image = meta_image?.url
+
+      break
+  }
+
+  return metadata
+}

--- a/components/Meta/shape.js
+++ b/components/Meta/shape.js
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types'
-import prismicImageShare from 'shapes/prismic/image'
+import prismicImageShape from 'shapes/prismic/image'
 
 const metaProps = {
   meta_title: PropTypes.string,
   meta_description: PropTypes.string,
-  meta_image: prismicImageShare,
+  meta_image: PropTypes.oneOfType[(PropTypes.string, prismicImageShape)],
 }
 
 export { metaProps }

--- a/components/Page/index.js
+++ b/components/Page/index.js
@@ -5,6 +5,7 @@ import Slices from 'components/Slices'
 import headerShape from 'components/Header/shape'
 import { useRouter } from 'next/router'
 import pageShape from './shape'
+import { getMetaData } from 'components/Meta/lib'
 
 const Page = ({ page, header, preview }) => {
   const router = useRouter()
@@ -12,13 +13,8 @@ const Page = ({ page, header, preview }) => {
     return <ErrorPage statusCode={404} />
   }
 
-  const metadata = {
-    /* eslint-disable react/prop-types */
-    meta_title: page?.meta_title,
-    meta_description: page?.meta_description,
-    meta_image: page?.meta_image,
-    /* eslint-enable */
-  }
+  // Set page metadata
+  const metadata = getMetaData(page)
 
   return (
     <Layout preview={preview} metadata={metadata} header={header}>

--- a/constants/metadata.js
+++ b/constants/metadata.js
@@ -1,0 +1,10 @@
+// TODO These defaults are overwritten in Prismic via Singleton Metadata or Template-specific overrides
+const metaDefaults = {
+  TWITTER_HANDLE: '{@twitterHandle}',
+  TITLE: '{Default Title}',
+  DESCRIPTION: '{Default description (50 - 155 characters)}',
+  DIVIDER: '|',
+  IMAGE: '/images/share.jpg', // TODO should be 1200 x 627px
+}
+
+export default metaDefaults

--- a/shapes/prismic/image.js
+++ b/shapes/prismic/image.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 
-const prismicImageShare = PropTypes.shape({
+const prismicImageShape = PropTypes.shape({
   dimensions: PropTypes.shape({
     width: PropTypes.number,
     height: PropTypes.number,
@@ -10,4 +10,4 @@ const prismicImageShare = PropTypes.shape({
   alt: PropTypes.string,
 })
 
-export default prismicImageShare
+export default prismicImageShape


### PR DESCRIPTION
– Created constants file for metadata
– Created lib that can be shared across all templates for setting metadata
– Added an additional metadata fallback set by prismic singleton

I've been using a metadata singleton to set default metadata for sites:
1. Should I make in base prismic repo and pass those in for the `layout.js` `defaults` prop being passed into the metadata component?
2. Probably doesnt matter, but when the global var pr gets merged in, would it make sense to have the metadata lib set that default var, instead of passing the global defaults in?