### PR TITLE
Fix GA Script

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -10,7 +10,10 @@ export default class MyDocument extends Document {
           {process.env.NODE_ENV === 'production' && (
             <>
               {/* Global Site Tag (gtag.js) - Google Analytics */}
-              <Script src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} />
+              <script
+                async
+                src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+              />
               <script
                 dangerouslySetInnerHTML={{
                   __html: `

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,5 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 import { GA_TRACKING_ID } from 'lib/analytics'
-import Script from 'next/script'
 
 export default class MyDocument extends Document {
   render() {


### PR DESCRIPTION
Fixes an issue with `next/script` not rendering analytics script. Reverted to standard script async tag. Tested on personal site with Google Tag Assistant, all seems well.