### PR TITLE
Default htmlSerializer + Rich Text helper

### DIFF
--- a/components/Slices/RichText/index.js
+++ b/components/Slices/RichText/index.js
@@ -1,11 +1,12 @@
 import { RichText } from 'prismic-reactjs'
 import styles from './index.module.scss'
 import prismicRichTextShare from 'shapes/prismic/richtext'
+import { htmlSerializer } from 'lib/richtext'
 
 const RichTextComponent = ({ richtext }) => {
   return (
     <div className={styles.container}>
-      <RichText render={richtext} />
+      <RichText render={richtext} htmlSerializer={htmlSerializer} />
     </div>
   )
 }

--- a/lib/richtext.js
+++ b/lib/richtext.js
@@ -1,0 +1,24 @@
+// Re-formats Prismic HTML
+export const htmlSerializer = (type, element, children, key) => {
+  switch (type) {
+    case 'paragraph':
+      // Remove weird LSEP character on windows machines
+      // Usually generated from copy + paste in other programs
+      if (element.text.match(/\u2028/)) {
+        const updatedText = element.text.replace(/\u2028/g, ' ')
+
+        return (
+          <p
+            key={key}
+            suppressHydrationWarning
+            dangerouslySetInnerHTML={{ __html: updatedText }}
+          />
+        )
+      }
+
+      break
+    default:
+      // Return null to stick with the default behavior
+      return null
+  }
+}


### PR DESCRIPTION
Adds a default `htmlSerializer` function for `RichText` component. Additionally, this adds a helper function which removes special characters that might exist in the copy due to copying and pasting from third party applications.