### PR TITLE
Fetch links for home page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -13,7 +13,10 @@ export async function getStaticProps({ preview = false, previewData }) {
     fetchLinks: pageSlugFetchLinks,
     ref,
   })
-  const page = await client.getByID(HOME_ID, { ref })
+  const page = await client.getByID(HOME_ID, {
+    ref,
+    fetchLinks: pageSlugFetchLinks,
+  })
 
   return {
     props: {


### PR DESCRIPTION
I spent way too long trying to figure out why my relationship field wasn't working with fetchLinks on my home page. I wanna make sure that doesn't happen again in the future. I think the home page should fetch links as well.