### PR TITLE
Meta tags for LinkedIn

### DIFF
--- a/components/Layout/Meta/index.js
+++ b/components/Layout/Meta/index.js
@@ -48,6 +48,8 @@ const Meta = ({ metadata, defaults }) => {
       <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
       <meta name="description" content={description} />
       <meta property="og:image" content={image} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
       <meta name="twitter:card" content="summary" />
       <meta name="twitter:site" content={metaDefaults.TWITTER_HANDLE} />
       <meta name="twitter:title" content={title} />


### PR DESCRIPTION
Without the added tags, LinkedIn automatically finds the page title to display in the share card, which is not always ideal.